### PR TITLE
Cache Twitch API tokens

### DIFF
--- a/BotUtils.py
+++ b/BotUtils.py
@@ -6,7 +6,7 @@ import aiohttp
 import urllib
 import json
 import re
-from config import apiKeys
+from config import apiKeys, cache
 from PIL import Image, ImageOps
 
 async def REST(url: str, method='GET', headers=None, data=None, auth=None, returns='json'):
@@ -27,6 +27,19 @@ async def REST(url: str, method='GET', headers=None, data=None, auth=None, retur
             if len(temp) == 1:
                 return temp[0]
             return temp
+
+def getCache(key: str) -> str:
+    if not key in cache:
+        return None
+ 
+    value = cache[key]
+    cache.pop(key)
+    return value
+
+def setCache(key: str, value: str):
+    if key in cache:
+        raise Exception()
+    cache.append({key: value})
 
 def escapeURL(url: str) -> str:
     return urllib.parse.quote(url)

--- a/BotUtils.py
+++ b/BotUtils.py
@@ -36,6 +36,17 @@ def getCache(key: str) -> str:
     cache.pop(key)
     return value
 
+async def getTwitchToken() -> str:
+    token = getCache('twitchToken')
+    if token:
+        authenticate = await REST('https://id.twitch.tv/oauth2/validate', headers={'Authorization': 'Bearer ' + token})
+    if not token or 'status' in authenticate:
+        # Invalid token
+        token = await REST(f"https://id.twitch.tv/oauth2/token?client_id={getAPIKey('twitchID')}&client_secret={getAPIKey('twitchSecret')}&grant_type=client_credentials", method='POST')
+        token = token['access_token']
+        setCache('twitchToken', token)
+    return token
+
 def setCache(key: str, value: str):
     if key in cache:
         raise Exception()

--- a/cogs/apis/igdb.py
+++ b/cogs/apis/igdb.py
@@ -1,5 +1,5 @@
 from discord.ext import commands
-from BotUtils import REST, getAPIKey, escapeURL
+from BotUtils import REST, getAPIKey, escapeURL, getTwitchToken
 from datetime import datetime
 import discord
 
@@ -10,9 +10,7 @@ class IGDB(commands.Cog):
     @commands.command(name='igdb', aliases=['game', 'games'])
     async def IGDBAPI(self, ctx, *, title):
         """Gets information about videogames using IGDB.com"""
-        # TODO: Cache tokens
-        token = await REST(f"https://id.twitch.tv/oauth2/token?client_id={getAPIKey('twitchID')}&client_secret={getAPIKey('twitchSecret')}&grant_type=client_credentials", method='POST')
-        token = token['access_token']
+        token = await getTwitchToken()
         
         title = title.replace("'", "\\'").replace('"', '\\"')
         exactmatch = f'where name ~ "{title}";sort url asc;'

--- a/cogs/apis/twitch.py
+++ b/cogs/apis/twitch.py
@@ -1,5 +1,5 @@
 from discord.ext import commands
-from BotUtils import REST, getAPIKey, escapeURL, getCache, setCache
+from BotUtils import REST, getAPIKey, escapeURL, getTwitchToken
 from datetime import datetime
 import discord
 
@@ -29,14 +29,7 @@ class Twitch(commands.Cog):
     @commands.command(name='twitch')
     async def TwitchAPI(self, ctx, *, user):
         """Gets information about twitch users"""
-        token = getCache('twitchToken')
-        if token:
-            authenticate = await REST('https://id.twitch.tv/oauth2/validate', headers={'Authorization': 'Bearer ' + token})
-        if not token or 'status' in authenticate:
-            # Invalid token
-            token = await REST(f"https://id.twitch.tv/oauth2/token?client_id={getAPIKey('twitchID')}&client_secret={getAPIKey('twitchSecret')}&grant_type=client_credentials", method='POST')
-            token = token['access_token']
-            setCache('twitchToken', token)
+        token = await getTwitchToken()
         data = await REST(f"https://api.twitch.tv/helix/users?login={escapeURL(user)}", headers={'Authorization': 'Bearer ' + token, 'Client-ID': getAPIKey('twitchID')})
         data = data['data'][0]
         stream = await REST(f"https://api.twitch.tv/helix/streams?user_login={escapeURL(user)}", headers={'Authorization': 'Bearer ' + token, 'Client-ID': getAPIKey('twitchID')})

--- a/cogs/apis/twitch.py
+++ b/cogs/apis/twitch.py
@@ -1,5 +1,5 @@
 from discord.ext import commands
-from BotUtils import REST, getAPIKey, escapeURL
+from BotUtils import REST, getAPIKey, escapeURL, getCache, setCache
 from datetime import datetime
 import discord
 
@@ -29,9 +29,14 @@ class Twitch(commands.Cog):
     @commands.command(name='twitch')
     async def TwitchAPI(self, ctx, *, user):
         """Gets information about twitch users"""
-        # TODO: Cache tokens
-        token = await REST(f"https://id.twitch.tv/oauth2/token?client_id={getAPIKey('twitchID')}&client_secret={getAPIKey('twitchSecret')}&grant_type=client_credentials", method='POST')
-        token = token['access_token']
+        token = getCache('twitchToken')
+        if token:
+            authenticate = await REST('https://id.twitch.tv/oauth2/validate', headers={'Authorization': 'Bearer ' + token})
+        if not token or 'status' in authenticate:
+            # Invalid token
+            token = await REST(f"https://id.twitch.tv/oauth2/token?client_id={getAPIKey('twitchID')}&client_secret={getAPIKey('twitchSecret')}&grant_type=client_credentials", method='POST')
+            token = token['access_token']
+            setCache('twitchToken', token)
         data = await REST(f"https://api.twitch.tv/helix/users?login={escapeURL(user)}", headers={'Authorization': 'Bearer ' + token, 'Client-ID': getAPIKey('twitchID')})
         data = data['data'][0]
         stream = await REST(f"https://api.twitch.tv/helix/streams?user_login={escapeURL(user)}", headers={'Authorization': 'Bearer ' + token, 'Client-ID': getAPIKey('twitchID')})

--- a/config.example.py
+++ b/config.example.py
@@ -3,6 +3,7 @@ import logging
 import os
 from datetime import datetime
 uptime = datetime.now()
+cache = []
 
 token = '[TOKEN]'
 description ='Lynn'


### PR DESCRIPTION
Twitch probably doesn't appriciate creating a new token for every API call, so cache them instead and only create a new one if current token is invalidated